### PR TITLE
Ftr/5 "fill" as a possible value for "size" in edirom-icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ It provides:
 ```
 
 
+### Fill Mode
+
+Set `size="fill"` to make the icon expand to fill its container:
+
+```html
+<div style="width: 64px; height: 64px;">
+    <edirom-icon name="home" size="fill"></edirom-icon>
+</div>
+```
+
+In fill mode:
+- The host switches to `display: block` with `width: 100%; height: 100%`
+- The icon is centered (flexbox) and scaled to fit via `min(100cqi, 100cqb)` using CSS container queries
+- Useful for icon buttons or containers where the icon should occupy the full available space
+
+
 ### Spin and Rotate
 
 ```html
@@ -106,30 +122,31 @@ If the element contains children, the component renders a `<slot>` instead of a 
 
 ## Attributes
 
-| Attribute     | Type                          | Description |
-|---------------|------------------------------|-------------|
-| `name`        | string                        | Icon name (ligature text) |
-| `size`        | number \| CSS size \| `12px`    | Icon size |
-| `color`       | CSS color                     | Icon color |
-| `spin`        | boolean                       | Enables infinite rotation |
-| `rotate`      | number \| `45deg`             | Rotates icon |
-| `aria-label`  | string                        | Accessibility label |
-| `role`        | string                        | ARIA role |
-| `button`      | boolean                       | Enables button styling + keyboard |
-| `pressed`     | boolean                       | Applies pressed styling |
+| Attribute     | Type                                      | Description |
+|---------------|------------------------------------------|-------------|
+| `name`        | string                                    | Icon name (ligature text) |
+| `size`        | number \| CSS size \| `12px` \| `"fill"` | Icon size; use `"fill"` to expand to fit container |
+| `color`       | CSS color                                 | Icon color |
+| `spin`        | boolean                                   | Enables infinite rotation |
+| `rotate`      | number \| `45deg`                         | Rotates icon |
+| `aria-label`  | string                                    | Accessibility label |
+| `role`        | string                                    | ARIA role |
+| `button`      | boolean                                   | Enables button styling + keyboard |
+| `pressed`     | boolean                                   | Applies pressed styling |
 
 
 ## Size Attribute Formats
 
 The `size` attribute supports:
 
-| Value   | Result |
-|---------|--------|
-| `"24"`  | `24px` |
-| `"32px"`| `32px` |
-| `"2em"` | `2em`  |
-| `"150%"`| `150%` |
-| `"2x"`  | `2em`  |
+| Value    | Result |
+|----------|--------|
+| `"24"`   | `24px` |
+| `"32px"` | `32px` |
+| `"2em"`  | `2em`  |
+| `"150%"` | `150%` |
+| `"2x"`   | `2em`  |
+| `"fill"` | Fills the parent container (sets `display: block`, `width/height: 100%`, uses CSS container queries to scale) |
 
 
 ## Styling

--- a/src/edirom-icon.js
+++ b/src/edirom-icon.js
@@ -80,17 +80,20 @@ class EdiromIcon extends HTMLElement {
         const spin = this.hasAttribute('spin');
         const rotate = this.getAttribute('rotate');
 
+        const isFill = sizeAttr === 'fill';
+
         // Build the internal DOM only once
         this._shadow.innerHTML = ''; // clear
         const style = document.createElement('style');
         style.textContent = `
-            :host { display: inline-block; vertical-align: middle; line-height: 0; }
+            :host { display: ${isFill ? 'block' : 'inline-block'}; ${isFill ? 'width: 100%; height: 100%; container-type: size;' : 'vertical-align: middle;'} line-height: 0; }
             .icon {
-                display: inline-block;
+                display: ${isFill ? 'flex' : 'inline-block'};
+                ${isFill ? 'width: 100%; height: 100%; align-items: center; justify-content: center;' : ''}
                 font-family: 'Material Symbols Outlined';
                 font-weight: normal;
                 font-style: normal;
-                font-size: var(--edirom-icon-size, 24px);
+                font-size: ${isFill ? 'min(100cqi, 100cqb)' : 'var(--edirom-icon-size, 24px)'};
                 line-height: 1;
                 letter-spacing: normal;
                 text-transform: none;
@@ -139,8 +142,8 @@ class EdiromIcon extends HTMLElement {
         // apply color
         if (color) wrapper.style.setProperty('--edirom-icon-color', color);
 
-        // apply size (support number and units)
-        if (sizeAttr) {
+        // apply size (support number and units, but not 'fill' which is handled via CSS)
+        if (sizeAttr && !isFill) {
             const sizeValue = EdiromIcon._normalizeSize(sizeAttr);
             wrapper.style.setProperty('--edirom-icon-size', sizeValue);
         }


### PR DESCRIPTION
Refs #5 

Possible test:

```html
<div>
<edirom-icon name="info" size="fill"/>
</div>
```

```css
div {
width: 200px;
height: 200px;
}
```

The icon should be 200px high/wide.